### PR TITLE
Fix install destination so shell helpers are actually sourced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX ?= $(HOME)
 PIPX_HOME ?= $(HOME)/.local/pipx
 PIPX_BIN_DIR ?= $(HOME)/.local/bin
 PIPX_STATE_HOME ?= $(HOME)/.local/state
-SHELL_HELPER_DEST ?= $(PREFIX)/.dotfiles/bash/tsd
+SHELL_HELPER_DEST ?= $(PREFIX)/.dotfiles/bash/rc_post/tsd
 export PYTHONPATH := src
 
 .PHONY: all install lint test clean TAGS


### PR DESCRIPTION
SHELL_HELPER_DEST pointed to ~/.dotfiles/bash/tsd, which is never
sourced. The dotfiles bashrc scans rc_post/*, so install there instead.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
